### PR TITLE
[Fix] 2 edge cases and markdown format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-#airline-weather.vim
+# airline-weather.vim
 
 ![screenshot](https://raw.githubusercontent.com/Wildog/airline-weather.vim/master/screenshot.png)
 This is a vim-airline extension to show current weather on the right end of the status line, just like the weather segment in Powerline.
 
 __This extension depends on [vim-airline](https://github.com/bling/vim-airline) and [webapi-vim](https://github.com/mattn/webapi-vim), you should install them first.__
 
-##Installation
+## Installation
 
-* ###Use Vundle
+* ### Use Vundle
 
     Make sure you have these lines in your .vimrc
 
@@ -17,10 +17,11 @@ __This extension depends on [vim-airline](https://github.com/bling/vim-airline) 
 
     :PluginInstall
 
-* ###Manually
-Make sure you have installed [vim-airline](https://github.com/bling/vim-airline) and [webapi-vim](https://github.com/mattn/webapi-vim), then put files to corresponding directories.
+* ### Manually
 
-##Usage
+  Make sure you have installed [vim-airline](https://github.com/bling/vim-airline) and [webapi-vim](https://github.com/mattn/webapi-vim), then put files to corresponding directories.
+
+### Usage
 
 * Set location
 
@@ -68,7 +69,10 @@ Make sure you have installed [vim-airline](https://github.com/bling/vim-airline)
 
 * Plus, you can force refresh the weather by
 
-        :call RefreshWeather()
+    ```
+    :call RefreshWeather()
+    ```
 
-##LICENSE
+## LICENSE
+
 MIT


### PR DESCRIPTION
[Fix] 从 API 下载到错误信息时，下一次打开 vim 无法更新未过期但没有正确内容的 cache 文件（例如 json 内容为 404 报错信息）。

[Fix] ping 的 TTL 设置较小( `ping -q -c 1 -t 1 baidu.com` )，导致有时误判为无连接。使用 `-W` 来设置超时时间。

[Fix] 调整 README.md 的 Markdown 格式